### PR TITLE
Add EDA functionality

### DIFF
--- a/control/README.md
+++ b/control/README.md
@@ -42,9 +42,9 @@ This is the 'new' version of the control software for the iSIM microscope. It's 
     mmcore install -d C:\isim
     mmcore use C:\iSIM\Micro-Manager_2.0.3_20250523 #replace with used version
     ```
-    >You can use this to install a certain version (20250523 works when this is written)  
+    >You can use this to install a certain version (20250523 works when this is written)
     `-r, --release TEXT    Release date. e.g. 20210201  \[default: latest-compatible]`
-    
+
 1. Make a shortcut to run C:\iSIM\iSIM\control\main.ps1
 1. For each user follow [add new user](../docs/new_user.md)
 
@@ -64,3 +64,6 @@ The design for the sample folder is here [Fusion360](https://a360.co/3FxlTVk), [
 
 # Alignment
 The alignment procedure has to be used from the old software [Alignment](../gui/README.md#alignment)
+
+# EDA
+The system is set up to perform eda acquisition based on [pymmcore-eda](https://github.com/LEB-EPFL/pymmcore-eda). Example files [with](./src/isim_control/eda/basic.py) and [without](./src/isim_control/eda/gui.py) a preview window can be found in the [eda](./src/isim_control/eda) folder. More examples on how to do more complex EDA acquisitions and how to 'close the loop' can be found in the pymmcore-eda repository.

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -33,4 +33,4 @@ build-backend = "hatchling.build"
 source = ['isim_control']
 
 [tool.uv.sources]
-pymmcore-eda = { path = "../../pymmcore-eda", editable = true }
+pymmcore-eda = { git = "https://github.com/LEB-EPFL/pymmcore-eda.git", rev = "v0.1.1" }

--- a/control/src/isim_control/eda/_stack_viewer/__init__.py
+++ b/control/src/isim_control/eda/_stack_viewer/__init__.py
@@ -1,0 +1,5 @@
+from ._channel_row import CMAPS
+from ._datastore import QOMEZarrDatastore
+from ._stack_viewer import StackViewer
+
+__all__ = ["StackViewer", "CMAPS", "QOMEZarrDatastore"]

--- a/control/src/isim_control/eda/_stack_viewer/_channel_row.py
+++ b/control/src/isim_control/eda/_stack_viewer/_channel_row.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
+
+import cmap
+from qtpy import QtCore, QtGui, QtWidgets
+from superqt import QColormapComboBox, QRangeSlider
+
+if TYPE_CHECKING:
+    from qtpy.QtGui import QMouseEvent
+    from useq import Channel
+
+try:
+    pass
+except ImportError as e:
+    raise ImportError(
+        "vispy is required for Channel_row. "
+        "Please run `pip install pymmcore-widgets[image]`"
+    ) from e
+
+
+CMAPS = ["gray", "BOP_Blue", "BOP_Purple"]
+
+
+def try_cast_colormap(val: Any) -> cmap.Colormap | None:
+    """Try to cast `val` to a cmap.Colormap instance, return None if it fails."""
+    if isinstance(val, cmap.Colormap):
+        return val
+    with suppress(Exception):
+        return cmap.Colormap(val)
+    return None
+
+
+class ChannelRow(QtWidgets.QWidget):
+    """Row of channel boxes."""
+
+    visible = QtCore.Signal(bool, int)
+    autoscale = QtCore.Signal(bool, int)
+    new_clims = QtCore.Signal(tuple, int)
+    new_cmap = QtCore.Signal(cmap.Colormap, int)
+    selected = QtCore.Signal(int)
+    new_channel = QtCore.Signal(str, int)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent=parent)
+        self.restore_data()
+
+        self.my_layout = QtWidgets.QGridLayout()
+        self.setLayout(self.my_layout)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        self.boxes: dict[int, ChannelBox] = {}
+        self.new_cmap.connect(self._handle_channel_cmap)
+        self.visible.connect(self.channel_visibility)
+        self.new_channel.connect(self._add_channel)
+        self.current_channel: int | None = None
+
+    def add_channel(self, channel: Channel | None, index: int | None = None) -> None:
+        """Add a channel to the row."""
+        if index is None:
+            index = len(self.boxes)
+        if channel is None:
+            name = "Default"
+        else:
+            name = channel.config
+        self.new_channel.emit(name, index)
+
+    def _add_channel(self, name: str, index: int) -> None:
+        channel_box = ChannelBox(name, cmaps=self.cmap_names, parent=self)
+        self.boxes[index] = channel_box
+
+        channel_box.show_channel.stateChanged.connect(self.emit_visible)
+        channel_box.autoscale_chbx.stateChanged.connect(self.emit_autoscale)
+        channel_box.slider.sliderMoved.connect(self.emit_new_clims)
+        channel_box.color_choice.currentColormapChanged.connect(self.emit_new_cmap)
+
+        channel_box.color_choice.setCurrentIndex(index)
+        channel_box.clicked.connect(self._handle_channel_choice)
+        self.my_layout.addWidget(channel_box, 0, index)
+        channel_box.color_choice.setCurrentColormap(
+            self.channel_cmaps.get(name, "gray")
+        )
+
+    def emit_visible(self, state: int) -> None:
+        sender = self.sender()
+        self.visible.emit(bool(state), list(self.boxes.keys())[list(self.boxes.values()).index(sender.parent())])
+
+    def emit_autoscale(self, state: int) -> None:
+        sender = self.sender()
+        self.autoscale.emit(
+            bool(state), list(self.boxes.keys())[list(self.boxes.values()).index(sender.parent())]
+        )
+
+    def emit_new_clims(self, value: tuple[int, int]) -> None:
+        sender = self.sender()
+        self.new_clims.emit(value, list(self.boxes.keys())[list(self.boxes.values()).index(sender.parent())])
+
+    def emit_new_cmap(self, cmap: cmap.Colormap) -> None:
+        sender = self.sender()
+        self.new_cmap.emit(cmap, list(self.boxes.keys())[list(self.boxes.values()).index(sender.parent())])
+
+    def _disconnect(self) -> None:
+        for box in self.boxes.values():
+            box.show_channel.stateChanged.disconnect(self.emit_visible)
+            box.autoscale_chbx.stateChanged.disconnect(self.emit_autoscale)
+            box.slider.sliderMoved.disconnect(self.emit_new_clims)
+            box.color_choice.currentColormapChanged.disconnect(self.emit_new_cmap)
+            box.clicked.disconnect(self._handle_channel_choice)
+
+    def channel_visibility(self, visible: bool, channel: int) -> None:
+        """If the current channel is made invisible, choose a different one."""
+        if self.current_channel == channel and not visible:
+            try:
+                if channel > 0:
+                    channel_to_set = list(self.boxes.keys())[channel - 1]
+                else:
+                    channel_to_set = list(self.boxes.keys())[1]
+            except IndexError:
+                channel_to_set = 0
+            # channel_to_set = 0 if len(self.channel_row.boxes) == 1 else channel_to_set
+            self._handle_channel_choice(
+                self.boxes[channel_to_set].channel
+            )
+            self._handle_channel_choice(self.boxes[channel_to_set].channel)
+
+    def _handle_channel_choice(self, channel: str) -> None:
+        """Channel was chosen, adjust GUI and send signal."""
+        if len(self.boxes) == 1:
+            return
+        for idx, channel_box in enumerate(self.boxes.values()):
+            if channel_box.channel != channel:
+                channel_box.setStyleSheet("ChannelBox{border: 1px solid}")
+            else:
+                channel_box.setStyleSheet("ChannelBox{border: 3px solid}")
+                channel_box.show_channel.setChecked(True)
+                self.selected.emit(idx)
+                self.current_channel = idx
+
+    def _handle_channel_cmap(self, colormap: cmap.Colormap | str, i: int) -> None:
+        color = colormap if isinstance(colormap, str) else colormap.name
+        if color in self.cmap_names:
+            self.cmap_names.remove(color)
+        self.cmap_names.insert(0, color)
+        self.boxes[i].color_choice.addColormap(color)
+        self.boxes[i].color_choice.setCurrentColormap(color)
+        self.channel_cmaps[self.boxes[i].channel] = color
+        self.qt_settings.setValue("channel_cmaps", self.channel_cmaps)
+        self.qt_settings.setValue("cmap_names", self.cmap_names)
+
+    def restore_data(self) -> None:
+        """Restore data from previous session."""
+        self.qt_settings = QtCore.QSettings("pymmcore_widgets", self.__class__.__name__)
+        self.cmap_names = self.qt_settings.value(
+            "cmap_names", ["gray", "magenta", "cyan"]
+        )
+        self.channel_cmaps = self.qt_settings.value("channel_cmaps", {})
+        print(self.channel_cmaps)
+
+
+class ChannelBox(QtWidgets.QWidget):
+    """Box that represents a channel and gives some way of interaction."""
+
+    clicked = QtCore.Signal(str)
+
+    def __init__(
+        self,
+        name: str | None = None,
+        cmaps: list | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent=parent)
+        if name is None:
+            name = "Default"
+        self.channel = name
+        self.setLayout(QtWidgets.QGridLayout())
+        self.show_channel = QtWidgets.QCheckBox(name)
+        self.show_channel.setChecked(True)
+        self.show_channel.setStyleSheet("font-weight: bold")
+        self.layout().addWidget(self.show_channel, 0, 0)
+        self.color_choice = QColormapComboBox(allow_user_colormaps=True)
+
+        if cmaps is None:
+            cmaps = CMAPS
+        for my_cmap in cmaps:
+            self.color_choice.addColormap(my_cmap)
+
+        self.layout().addWidget(self.color_choice, 0, 1)
+        self.autoscale_chbx = QtWidgets.QCheckBox("Auto")
+        self.autoscale_chbx.setChecked(True)
+        self.layout().addWidget(self.autoscale_chbx, 0, 2)
+        # self.histogram = HistPlot()
+        # self.layout().addWidget(self.histogram, 1, 0, 1, 3)
+        self.slider = QRangeSlider(QtCore.Qt.Horizontal)
+        self.layout().addWidget(self.slider, 2, 0, 1, 3)
+        self.setStyleSheet("ChannelBox{border: 1px solid}")
+
+    def mousePressEvent(self, event: QMouseEvent | None) -> None:
+        self.clicked.emit(self.channel)
+
+
+class QColorComboBox(QtWidgets.QComboBox):
+    """A drop down menu for selecting colors."""
+
+    # Adapted from https://stackoverflow.com/questions/64497029/a-color-drop-down-selector-for-pyqt5
+
+    # signal emitted if a color has been selected
+    selectedColor = QtCore.Signal(QtGui.QColor)
+
+    def __init__(
+        self, parent: QtWidgets.QWidget | None = None, enableUserDefColors: bool = False
+    ) -> None:
+        # init QComboBox
+        super().__init__(parent)
+
+        # enable the line edit to display the currently selected color
+        self.setEditable(True)
+        # read only so that there is no blinking cursor or sth editable
+        self.lineEdit().setReadOnly(True)
+        # self.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        # text that shall be displayed for the option
+        # to pop up the QColorDialog for user defined colors
+        self._userDefEntryText = "New"
+        # add the option for user defined colors
+        if enableUserDefColors:
+            self.addItem(self._userDefEntryText)
+
+        self._currentColor: QtGui.QColor = QtGui.QColor()
+
+        self.activated.connect(self._color_selected)
+        # self.setStyleSheet("QComboBox:drop-down {
+        # image: none; background: red; border: 1px grey;}")
+
+    def addColors(
+        self, colors: list[list[QtGui.QColor]] | list[list[int]] | list[list[float]]
+    ) -> None:
+        """Adds colors to the QComboBox."""
+        for a_color in colors:
+            # if input is not a QColor, try to make it one
+            if not (isinstance(a_color, QtGui.QColor)):
+                try:
+                    a_color = QtGui.QColor(a_color)
+                except TypeError:
+                    if max(a_color) < 2:
+                        a_color = [int(x * 255) for x in a_color]
+                    a_color = QtGui.QColor(*a_color)
+
+            # avoid duplicates
+            if self.findData(a_color) == -1:
+                # add the new color and set the background color of that item
+                self.addItem("", userData=a_color)
+                self.setItemData(
+                    self.count() - 1, QtGui.QColor(a_color), QtCore.Qt.BackgroundRole
+                )
+
+    def addColor(self, color: QtGui.QColor) -> None:
+        """Adds the color to the QComboBox."""
+        self.addColors([color])
+
+    def setColor(self, color: QtGui.QColor) -> None:
+        """Adds the color to the QComboBox and selects it."""
+        if isinstance(color, int):
+            self.setCurrentIndex(color)
+            self._currentColor = self.itemData(color)
+            self.lineEdit().setStyleSheet(
+                "background-color: " + self._currentColor.name()
+            )
+        else:
+            self._color_selected(self.findData(color), False)
+
+    def getCurrentColor(self) -> QtGui.QColor | None:
+        """Returns the currently selected QColor or None if not yet selected."""
+        return self._currentColor
+
+    def _color_selected(self, index: int, emitSignal: bool = True) -> None:
+        """Processes the selection of the QComboBox."""
+        # if a color is selected, emit the selectedColor signal
+        if self.itemText(index) == "":
+            self._currentColor = self.itemData(index)
+            if emitSignal:
+                self.selectedColor.emit(self._currentColor)
+
+        # if the user wants to define a custom color
+        elif self.itemText(index) == self._userDefEntryText:
+            # get the user defined color
+            new_color = QtWidgets.QColorDialog.getColor(
+                self._currentColor if self._currentColor else QtCore.Qt.white
+            )
+            if new_color.isValid():
+                # add the color to the QComboBox and emit the signal
+                self.addColor(new_color)
+                self._currentColor = new_color
+                if emitSignal:
+                    self.selectedColor.emit(self._currentColor)
+
+        # make sure that current color is displayed
+        if self._currentColor:
+            self.setCurrentIndex(self.findData(self._currentColor))
+            self.lineEdit().setStyleSheet(
+                "background-color: " + self._currentColor.name()
+            )
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QtWidgets.QApplication(sys.argv)
+    w = ChannelBox("empty", cmaps=CMAPS)
+    w.show()
+
+    sys.exit(app.exec_())

--- a/control/src/isim_control/eda/_stack_viewer/_datastore.py
+++ b/control/src/isim_control/eda/_stack_viewer/_datastore.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from psygnal import Signal
+from isim_control.eda._util.zarr_saver import POS_PREFIX, OMEZarrWriter
+from useq import MDAEvent
+import yaml
+from pathlib import Path
+import time
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    import numpy as np
+    import useq
+
+
+class QOMEZarrDatastore(OMEZarrWriter):
+    frame_ready = Signal(MDAEvent)
+
+    def __init__(self, store = None, overwrite=False) -> None:
+        self.store = store
+        super().__init__(store=store, overwrite=overwrite)
+
+    def sequenceStarted(self, sequence: useq.MDASequence) -> None:
+        self._used_axes = tuple(x for x in sequence.used_axes if x not in ['p'])
+        self.start_time = time.perf_counter()
+        super().sequenceStarted(sequence)
+        if self.store:
+            if self._mm_config:
+                with open(Path(self.store)/'mm_config.txt', 'w') as outfile:
+                    yaml.dump(self._mm_config, outfile, default_flow_style=False)
+
+    def frameReady(
+        self,
+        frame: np.ndarray,
+        event: useq.MDAEvent,
+        meta: dict[Any, Any] = None,
+    ) -> None:
+        timestamp = time.perf_counter() - self.start_time
+        meta = {"DeltaT": timestamp, **(meta or {})}
+        super().frameReady(frame, event, meta or {})
+        self.frame_ready.emit(event)
+
+    def get_frame(self, event: MDAEvent) -> np.ndarray:
+        key = f'{POS_PREFIX}{event.index.get("p", 0)}'
+        ary = self.position_arrays[key]
+
+        index = tuple(event.index.get(k) for k in self._used_axes)
+        data: np.ndarray = ary[index]
+        return data

--- a/control/src/isim_control/eda/_stack_viewer/_labeled_slider.py
+++ b/control/src/isim_control/eda/_stack_viewer/_labeled_slider.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import superqt
+from fonticon_mdi6 import MDI6
+from qtpy import QtCore, QtWidgets
+from superqt.fonticon import icon
+
+FIXED = QtWidgets.QSizePolicy.Policy.Fixed
+
+
+class QLabeledSlider(superqt.QLabeledSlider):
+    def __init__(
+        self,
+        name: str = "",
+        orientation: QtCore.Qt.Orientation = QtCore.Qt.Orientation.Horizontal,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(orientation, parent)
+        self.name = name
+        name_label = QtWidgets.QLabel(name.upper())
+
+        self._length_label = QtWidgets.QLabel()
+        self.rangeChanged.connect(self._on_range_changed)
+
+        self.play_btn = QtWidgets.QPushButton(icon(MDI6.play, color="gray"), "", self)
+        self.play_btn.setMaximumWidth(24)
+        self.play_btn.setCheckable(True)
+        self.play_btn.toggled.connect(self._on_play_toggled)
+
+        self.lock_btn = QtWidgets.QPushButton(
+            icon(MDI6.lock_open_outline, color="gray"), "", self
+        )
+        self.lock_btn.setCheckable(True)
+        self.lock_btn.setMaximumWidth(24)
+        self.lock_btn.toggled.connect(self._on_lock_toggled)
+
+        layout = cast(QtWidgets.QBoxLayout, self.layout())
+        layout.insertWidget(0, self.play_btn, 0, QtCore.Qt.AlignmentFlag.AlignRight)
+        layout.insertWidget(0, name_label)
+        # FIXME: the padding/vertical alignment is a bit off here
+        layout.addWidget(self._length_label, 0, QtCore.Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(self.lock_btn, 0, QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+        self.installEventFilter(self)
+        self.setPageStep(1)
+        self.last_val = 0
+
+    def _on_play_toggled(self, state: bool) -> None:
+        if state:
+            self.play_btn.setIcon(icon(MDI6.pause))
+            self._timer_id = self.startTimer(50)
+        else:
+            self.play_btn.setIcon(icon(MDI6.play))
+            self.killTimer(self._timer_id)
+
+    def _on_lock_toggled(self, state: bool) -> None:
+        if state:
+            self.lock_btn.setIcon(icon(MDI6.lock_outline, color="red"))
+        else:
+            self.lock_btn.setIcon(icon(MDI6.lock_open_outline, color="gray"))
+
+    def timerEvent(self, e: QtCore.QTimerEvent) -> None:
+        self.setValue((self.value() + 1) % self.maximum())
+
+    def _on_range_changed(self, min_: int, max_: int) -> None:
+        self._length_label.setText(f"/ {max_}")
+
+    def eventFilter(self, source: QtCore.QObject, event: QtCore.QEvent) -> Any:
+        if event.type() == QtCore.QEvent.Type.Paint and self.underMouse():
+            if self.value() != self.last_val:
+                self.sliderMoved.emit(self.value())
+        self.last_val = self.value()
+        return super().eventFilter(source, event)
+
+
+class LabeledVisibilitySlider(QLabeledSlider):
+    def _visibility(self, settings: dict[str, Any]) -> None:
+        if settings["index"] != self.name:
+            return
+        if settings["show"]:
+            self.show()
+        else:
+            self.hide()
+        self.setRange(0, settings["max"])

--- a/control/src/isim_control/eda/_stack_viewer/_save_button.py
+++ b/control/src/isim_control/eda/_stack_viewer/_save_button.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import zarr
+from fonticon_mdi6 import MDI6
+from qtpy.QtCore import QSize
+from qtpy.QtWidgets import QFileDialog, QPushButton, QWidget
+from superqt import fonticon
+
+from ._datastore import QOMEZarrDatastore
+
+if TYPE_CHECKING:
+    from qtpy.QtGui import QCloseEvent
+
+
+class SaveButton(QPushButton):
+    def __init__(
+        self,
+        datastore: QOMEZarrDatastore,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(parent=parent)
+        # self.setFont(QFont('Arial', 50))
+        # self.setMinimumHeight(30)
+        self.setIcon(fonticon.icon(MDI6.content_save_outline, color="gray"))
+        self.setIconSize(QSize(25, 25))
+        self.setFixedSize(30, 30)
+        self.clicked.connect(self._on_click)
+
+        self.datastore = datastore
+        self.save_loc = Path.home()
+
+    def _on_click(self) -> None:
+        self.save_loc, _ = QFileDialog.getSaveFileName(directory=str(self.save_loc))
+        if self.save_loc:
+            self._save_as_zarr(self.save_loc)
+
+    def _save_as_zarr(self, save_loc: str | Path) -> None:
+        dir_store = zarr.DirectoryStore(save_loc)
+        zarr.copy_store(self.datastore._group.attrs.store, dir_store)
+
+    def closeEvent(self, a0: QCloseEvent | None) -> None:
+        super().closeEvent(a0)
+
+
+if __name__ == "__main__":
+    from pymmcore_plus import CMMCorePlus
+    from qtpy.QtWidgets import QApplication
+    from useq import MDASequence
+
+    mmc = CMMCorePlus()
+    mmc.loadSystemConfiguration()
+
+    app = QApplication([])
+    seq = MDASequence(
+        time_plan={"interval": 0.01, "loops": 10},
+        z_plan={"range": 5, "step": 1},
+        channels=[{"config": "DAPI", "exposure": 1}, {"config": "FITC", "exposure": 1}],
+    )
+    datastore = QOMEZarrDatastore()
+    mmc.mda.events.sequenceStarted.connect(datastore.sequenceStarted)
+    mmc.mda.events.frameReady.connect(datastore.frameReady)
+
+    widget = SaveButton(datastore, mmc)
+    mmc.run_mda(seq)
+    widget.show()
+    app.exec_()

--- a/control/src/isim_control/eda/_util/_5d_writer_base.py
+++ b/control/src/isim_control/eda/_util/_5d_writer_base.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from abc import abstractmethod
+from collections import defaultdict
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
+
+
+if TYPE_CHECKING:
+    import numpy as np
+    import useq
+
+    class SupportsSetItem(Protocol):
+        def __setitem__(self, key: tuple[int, ...], value: np.ndarray) -> None: ...
+
+
+POS_PREFIX = "p"
+T = TypeVar("T", bound="SupportsSetItem")
+
+
+class _5DWriterBase(Generic[T]):
+    """Base class for writers that write 5D data to disk.
+
+    This is a general-purpose writer that can be used for writers that deal strictly
+    with a 5D data model (i.e. "tzcyx") such as the OME data model.  On each frameReady
+    event, it:
+
+        1. Determines the position being acquired
+        2. Calls `new_array` to create one for the position if it doesn't already exist
+        3. Determines the index to write the frame at
+        4. Calls `write_frame` to write the frame to the array at the index
+        5. Calls `store_frame_metadata` to store metadata for the frame.
+
+    Subclasses MUST implement the `new_array` method, which will create a new array to
+    hold the full experiment for each position.  Subclasses MAY also override the
+    `write_frame` method to customize how the data is written to disk, the
+    `finalize_metadata` method to write frame metadata to disk at the end of the
+    sequence, and the `store_frame_metadata` method to customize how metadata for each
+    frame is stored/handled
+
+    Attributes
+    ----------
+    position_arrays : dict[str, T]
+        Local cache of {position index -> T}, where T is the type of data to be written
+        by the writer (for example, `zarr.Array` or a `np.memmap`).  `T` must support
+        `__setitem__` for adding frames to a specific index.
+    frame_metadatas : defaultdict[str, list[dict]]
+        Will accumulate frame metadata for each frame as the experiment progresses.
+        It is up to subclasses to do something with it in `finalize_metadata()`, and it
+        will be cleared at the end of each sequence.
+    current_sequence : useq.MDASequence | None
+        The current sequence being written.  This will be set during `sequenceStarted`
+        and cleared during `sequenceFinished`.
+    position_sizes : list[dict[str, int]]
+        There will be one ordered dict, mapping dimension names to size, for each
+        position in the sequence. Each dict will contain `{dim: size}` pairs for each
+        dimension in the sequence. Dimensions with no size will be omitted, though
+        singletons will be included, and 'p' will be removed
+    """
+
+    def __init__(self) -> None:
+        # local cache of {position index -> zarr.Array}
+        # (will have a dataset for each position)
+        self.position_arrays: dict[str, T] = {}
+
+        # storage of individual frame metadata
+        # maps position key to list of frame metadata
+        self.frame_metadatas: defaultdict[str, list[dict]] = defaultdict(list)
+
+        # set during sequenceStarted and cleared during sequenceFinished
+        self.current_sequence: useq.MDASequence | None = None
+
+        # list of {dim_name: size} map for each position in the sequence
+        self.position_sizes: list[dict[str, int]] = []
+
+    # The next three methods - `sequenceStarted`, `sequenceFinished`, and `frameReady`
+    # are to be connected directly to the MDA's signals, perhaps via listener_connected
+
+    def sequenceStarted(self, seq: useq.MDASequence) -> None:
+        """On sequence started, simply store the sequence."""
+        self.frame_metadatas.clear()
+        self.current_sequence = seq
+        if seq:
+            self.position_sizes = position_sizes(seq)
+
+    def sequenceFinished(self, seq: useq.MDASequence) -> None:
+        """On sequence finished, clear the current sequence."""
+        self.finalize_metadata()
+        self.frame_metadatas.clear()
+        self.current_sequence = None
+        self.position_sizes = []
+
+    def frameReady(self, frame: np.ndarray, event: useq.MDAEvent, meta: dict) -> None:
+        """Write frame to the zarr array for the appropriate position."""
+        # get the position key to store the array in the group
+        p_index = event.index.get("p", 0)
+        key = f"{POS_PREFIX}{p_index}"
+        pos_sizes = self.position_sizes[p_index]
+        if key in self.position_arrays:
+            ary = self.position_arrays[key]
+        else:
+            # this is the first time we've seen this position
+            # create a new array in the group for it
+            if not self.current_sequence:
+                # This needs to be implemented for cases where we're not executing
+                # an MDASequence.  Or, we need to create a better "mock" MDASequence
+                # for generic Iterable[MDAEvent]
+                raise NotImplementedError(
+                    "Writing OME file without a MDASequence not yet implemented"
+                )
+
+            # create the new array, getting XY chunksize from the frame
+            # and total shape from the sequence.
+            sizes = pos_sizes.copy()
+            sizes["y"], sizes["x"] = frame.shape[-2:]
+            self.position_arrays[key] = ary = self.new_array(key, frame.dtype, sizes)
+
+        index = tuple(event.index[k] for k in pos_sizes)
+        self.write_frame(ary, index, frame)
+        self.store_frame_metadata(key, event, meta)
+
+    @abstractmethod
+    def new_array(
+        self, position_key: str, dtype: np.dtype, dim_sizes: dict[str, int]
+    ) -> T:
+        """Create a new array for position_key.
+
+        Should create a new array for the given position key, with the given dtype and
+        dimensions.
+
+        Parameters
+        ----------
+        position_key : str
+            The position key for the array.
+        dtype : np.dtype
+            The dtype for the array.
+        dim_sizes : dict[str, int]
+            Ordered mapping of dimension names to sizes.  This will not be more than 5D
+            for OME, and should only include the axis keys "tzcyx".
+            Example: `{"t": 10, "z": 3, "c": 2, "y": 512, "x": 512}`
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def write_frame(self, ary: T, index: tuple[int, ...], frame: np.ndarray) -> None:
+        """Write information in `frame` to the datastore `ary` at `index`.
+
+        Subclasses may override this method to customize how the data is written to
+        disk.  The default implementation is to simply write the frame to the array at
+        the given index with `ary[index] = frame`.  Depending on the type of datastore,
+        additional steps may be necessary to flush or sync the data to disk.
+
+        Parameters
+        ----------
+        ary : T
+            The full datastore for a given position.
+        index : tuple[int, ...]
+            The index to write the frame at.
+        frame : np.ndarray
+            The incoming frame to write to disk.
+        """
+        # WRITE DATA TO DISK
+        ary[index] = frame
+
+    def store_frame_metadata(self, key: str, event: useq.MDAEvent, meta: dict) -> None:
+        """Called during each frameReady event to store metadata for the frame.
+
+        Subclasses may override this method to customize how metadata is stored for each
+        frame, for example, to write it to disk immediately, or to store it in a
+        different format.
+
+        Parameters
+        ----------
+        key : str
+            The position key for the frame (e.g. "p0" for the first position).
+        event : useq.MDAEvent
+            The event that triggered the frameReady signal.
+        meta : dict
+            Metadata associated with the frame.
+        """
+        # needn't be re-implemented in subclasses
+        # default implementation is to store the metadata in self._frame_metas
+        # use finalize_metadata to write to disk at the end of the sequence.
+        if meta:
+            # fix serialization MDAEvent
+            # XXX: There is already an Event object in meta, this overwrites it.
+            event_json = event.json(exclude={"sequence"}, exclude_defaults=True)
+            meta["Event"] = json.loads(event_json)
+        self.frame_metadatas[key].append(meta or {})
+
+    def finalize_metadata(self) -> None:
+        """Called during sequenceFinished before clearing sequence metadata.
+
+        Subclasses may override this method to flush any accumulated frame metadata to
+        disk at the end of the sequence.
+        """
+
+
+def get_full_sequence_axes(sequence: useq.MDASequence) -> tuple[str, ...]:
+    """Get the combined axes from sequence and sub-sequences."""
+    # axes main sequence
+    main_seq_axes = list(sequence.used_axes)
+    if not sequence.stage_positions:
+        return tuple(main_seq_axes)
+    # axes from sub sequences
+    sub_seq_axes: list = []
+    for p in sequence.stage_positions:
+        if p.sequence is not None:
+            sub_seq_axes.extend(
+                [ax for ax in p.sequence.used_axes if ax not in main_seq_axes]
+            )
+    return tuple(main_seq_axes + sub_seq_axes)
+
+
+def position_sizes(seq: useq.MDASequence) -> list[dict[str, int]]:
+    """Return a list of size dicts for each position in the sequence.
+
+    There will be one dict for each position in the sequence. Each dict will contain
+    `{dim: size}` pairs for each dimension in the sequence. Dimensions with no size
+    will be omitted, though singletons will be included.
+    """
+    main_sizes = seq.sizes.copy()
+    main_sizes.pop("p", None)  # remove position
+
+    if not seq.stage_positions:
+        # this is a simple MDASequence
+        return [{k: v for k, v in main_sizes.items() if v}]
+
+    sizes = []
+    for p in seq.stage_positions:
+        if p.sequence is not None:
+            psizes = {k: v or main_sizes.get(k, 0) for k, v in p.sequence.sizes.items()}
+        else:
+            psizes = main_sizes.copy()
+        sizes.append({k: v for k, v in psizes.items() if v and k != "p"})
+    return sizes

--- a/control/src/isim_control/eda/_util/_channel_row.py
+++ b/control/src/isim_control/eda/_util/_channel_row.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import cmap
+from qtpy import QtCore, QtGui, QtWidgets
+from superqt import QColormapComboBox, QRangeSlider
+from useq import Channel
+
+if TYPE_CHECKING:
+    from qtpy.QtGui import QMouseEvent
+    from vispy import color
+
+try:
+    pass
+except ImportError as e:
+    raise ImportError(
+        "vispy is required for Channel_row. "
+        "Please run `pip install pymmcore-widgets[image]`"
+    ) from e
+
+
+CMAPS = ["Gray", "BOP_Blue", "BOP_Purple"]
+
+
+class ChannelRow(QtWidgets.QWidget):
+    """Row of channel boxes."""
+
+    visible = QtCore.Signal(bool, int)
+    autoscale = QtCore.Signal(bool, int)
+    new_clims = QtCore.Signal(tuple, int)
+    new_cmap = QtCore.Signal(cmap.Colormap, int)
+    selected = QtCore.Signal(int)
+
+    def __init__(
+        self,
+        num_channels: int = 5,
+        # https://cmap-docs.readthedocs.io/en/latest/
+        cmaps: list[
+            color.Colormap
+        ] = CMAPS,  # TODO: go with cmap to avoid vispy dependency
+    ) -> None:
+        super().__init__()
+        self.cmaps = cmaps
+
+        self.setLayout(QtWidgets.QHBoxLayout())
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        self.boxes = []
+        # TODO: Ideally we would know beforehand how many of these we need.
+        for i in range(num_channels):
+            channel_box = ChannelBox(Channel(config="empty"), cmaps=self.cmaps)
+            channel_box.show_channel.stateChanged.connect(
+                lambda state, i=i: self.visible.emit(state, i)
+            )
+            channel_box.autoscale_chbx.stateChanged.connect(
+                lambda state, i=i: self.autoscale.emit(state, i)
+            )
+            channel_box.slider.sliderMoved.connect(
+                lambda values, i=i: self.new_clims.emit(values, i)
+            )
+            channel_box.color_choice.currentColormapChanged.connect(
+                lambda color, i=i: self.new_cmap.emit(color, i)
+            )
+            channel_box.color_choice.setCurrentIndex(i)
+            channel_box.clicked.connect(self._handle_channel_choice)
+            channel_box.mousePressEvent(None)
+            channel_box.hide()
+            self.current_channel = i
+            self.boxes.append(channel_box)
+            self.layout().addWidget(channel_box)
+
+    def box_visibility(self, i: int, name: str | None = None) -> None:
+        self.boxes[i].visible = True
+        self.boxes[i].show()
+        self.boxes[i].autoscale_chbx.setChecked(True)
+        self.boxes[i].show_channel.setText(name)
+        self.boxes[i].channel = name
+        self.boxes[i].mousePressEvent(None)
+
+    def _handle_channel_choice(self, channel: str) -> None:
+        for idx, channel_box in enumerate(self.boxes):
+            if channel_box.channel != channel:
+                channel_box.setStyleSheet("ChannelBox{border: 1px solid}")
+            else:
+                self.selected.emit(idx)
+
+
+class ChannelBox(QtWidgets.QFrame):
+    """Box that represents a channel and gives some way of interaction."""
+
+    clicked = QtCore.Signal(str)
+
+    def __init__(
+        self,
+        channel: Channel,
+        cmaps: list | None = None,
+    ) -> None:
+        super().__init__()
+        self.channel = channel.config
+        self.setLayout(QtWidgets.QGridLayout())
+        self.show_channel = QtWidgets.QCheckBox(channel.config)
+        self.show_channel.setChecked(True)
+        self.show_channel.setStyleSheet("font-weight: bold")
+        self.layout().addWidget(self.show_channel, 0, 0)
+        self.color_choice = QColormapComboBox(allow_user_colormaps=True)
+
+        if cmaps is None:
+            cmaps = CMAPS
+        for my_cmap in cmaps:
+            self.color_choice.addColormap(my_cmap)
+
+        self.layout().addWidget(self.color_choice, 0, 1)
+        self.autoscale_chbx = QtWidgets.QCheckBox("Auto")
+        self.autoscale_chbx.setChecked(False)
+        self.layout().addWidget(self.autoscale_chbx, 0, 2)
+        self.slider = QRangeSlider(QtCore.Qt.Horizontal)
+        self.layout().addWidget(self.slider, 1, 0, 1, 3)
+        self.setStyleSheet("ChannelBox{border: 1px solid}")
+
+    def mousePressEvent(self, event: QMouseEvent | None) -> None:
+        self.setStyleSheet("ChannelBox{border: 3px solid}")
+        self.clicked.emit(self.channel)
+
+
+class QColorComboBox(QtWidgets.QComboBox):
+    """A drop down menu for selecting colors."""
+
+    # Adapted from https://stackoverflow.com/questions/64497029/a-color-drop-down-selector-for-pyqt5
+
+    # signal emitted if a color has been selected
+    selectedColor = QtCore.Signal(QtGui.QColor)
+
+    def __init__(
+        self, parent: QtWidgets.QWidget | None = None, enableUserDefColors: bool = False
+    ) -> None:
+        # init QComboBox
+        super().__init__(parent)
+
+        # enable the line edit to display the currently selected color
+        self.setEditable(True)
+        # read only so that there is no blinking cursor or sth editable
+        self.lineEdit().setReadOnly(True)
+        # self.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        # text that shall be displayed for the option
+        # to pop up the QColorDialog for user defined colors
+        self._userDefEntryText = "New"
+        # add the option for user defined colors
+        if enableUserDefColors:
+            self.addItem(self._userDefEntryText)
+
+        self._currentColor: QtGui.QColor = QtGui.QColor()
+
+        self.activated.connect(self._color_selected)
+        # self.setStyleSheet("QComboBox:drop-down {
+        # image: none; background: red; border: 1px grey;}")
+
+    def addColors(
+        self, colors: list[list[QtGui.QColor]] | list[list[int]] | list[list[float]]
+    ) -> None:
+        """Adds colors to the QComboBox."""
+        for a_color in colors:
+            # if input is not a QColor, try to make it one
+            if not (isinstance(a_color, QtGui.QColor)):
+                try:
+                    a_color = QtGui.QColor(a_color)
+                except TypeError:
+                    if max(a_color) < 2:
+                        a_color = [int(x * 255) for x in a_color]
+                    a_color = QtGui.QColor(*a_color)
+
+            # avoid duplicates
+            if self.findData(a_color) == -1:
+                # add the new color and set the background color of that item
+                self.addItem("", userData=a_color)
+                self.setItemData(
+                    self.count() - 1, QtGui.QColor(a_color), QtCore.Qt.BackgroundRole
+                )
+
+    def addColor(self, color: QtGui.QColor) -> None:
+        """Adds the color to the QComboBox."""
+        self.addColors([color])
+
+    def setColor(self, color: QtGui.QColor) -> None:
+        """Adds the color to the QComboBox and selects it."""
+        if isinstance(color, int):
+            self.setCurrentIndex(color)
+            self._currentColor = self.itemData(color)
+            self.lineEdit().setStyleSheet(
+                "background-color: " + self._currentColor.name()
+            )
+        else:
+            self._color_selected(self.findData(color), False)
+
+    def getCurrentColor(self) -> QtGui.QColor | None:
+        """Returns the currently selected QColor or None if not yet selected."""
+        return self._currentColor
+
+    def _color_selected(self, index: int, emitSignal: bool = True) -> None:
+        """Processes the selection of the QComboBox."""
+        # if a color is selected, emit the selectedColor signal
+        if self.itemText(index) == "":
+            self._currentColor = self.itemData(index)
+            if emitSignal:
+                self.selectedColor.emit(self._currentColor)
+
+        # if the user wants to define a custom color
+        elif self.itemText(index) == self._userDefEntryText:
+            # get the user defined color
+            new_color = QtWidgets.QColorDialog.getColor(
+                self._currentColor if self._currentColor else QtCore.Qt.white
+            )
+            if new_color.isValid():
+                # add the color to the QComboBox and emit the signal
+                self.addColor(new_color)
+                self._currentColor = new_color
+                if emitSignal:
+                    self.selectedColor.emit(self._currentColor)
+
+        # make sure that current color is displayed
+        if self._currentColor:
+            self.setCurrentIndex(self.findData(self._currentColor))
+            self.lineEdit().setStyleSheet(
+                "background-color: " + self._currentColor.name()
+            )
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QtWidgets.QApplication(sys.argv)
+    w = ChannelBox(Channel(config="empty"), cmaps=CMAPS)
+    w.show()
+
+    sys.exit(app.exec_())

--- a/control/src/isim_control/eda/_util/_labeled_slider.py
+++ b/control/src/isim_control/eda/_util/_labeled_slider.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import superqt
+from fonticon_mdi6 import MDI6
+from qtpy import QtCore, QtWidgets
+from superqt.fonticon import icon
+
+FIXED = QtWidgets.QSizePolicy.Policy.Fixed
+
+
+class QLabeledSlider(superqt.QLabeledSlider):
+    def __init__(
+        self,
+        name: str = "",
+        orientation: QtCore.Qt.Orientation = QtCore.Qt.Orientation.Horizontal,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(orientation, parent)
+        self.name = name
+        name_label = QtWidgets.QLabel(name.upper())
+        self.setSingleStep(1)
+        self.setPageStep(1)
+        self._length_label = QtWidgets.QLabel()
+        self.rangeChanged.connect(self._on_range_changed)
+
+        self.play_btn = QtWidgets.QPushButton(icon(MDI6.play, color="gray"), "", self)
+        self.play_btn.setMaximumWidth(24)
+        self.play_btn.setCheckable(True)
+        self.play_btn.toggled.connect(self._on_play_toggled)
+
+        self.lock_btn = QtWidgets.QPushButton(
+            icon(MDI6.lock_open_outline, color="gray"), "", self
+        )
+        self.lock_btn.setCheckable(True)
+        self.lock_btn.setMaximumWidth(24)
+        self.lock_btn.toggled.connect(self._on_lock_toggled)
+
+        layout = cast(QtWidgets.QBoxLayout, self.layout())
+        layout.insertWidget(0, self.play_btn, 0, QtCore.Qt.AlignmentFlag.AlignRight)
+        layout.insertWidget(0, name_label)
+        # FIXME: the padding/vertical alignment is a bit off here
+        layout.addWidget(self._length_label, 0, QtCore.Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(self.lock_btn, 0, QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+    def _on_play_toggled(self, state: bool) -> None:
+        if state:
+            self.play_btn.setIcon(icon(MDI6.pause))
+            self._timer_id = self.startTimer(50)
+        else:
+            self.play_btn.setIcon(icon(MDI6.play))
+            self.killTimer(self._timer_id)
+
+    def _on_lock_toggled(self, state: bool) -> None:
+        if state:
+            self.lock_btn.setIcon(icon(MDI6.lock_outline, color="red"))
+        else:
+            self.lock_btn.setIcon(icon(MDI6.lock_open_outline, color="gray"))
+
+    def timerEvent(self, e: QtCore.QTimerEvent) -> None:
+        self.setValue((self.value() + 1) % self.maximum())
+
+    def _on_range_changed(self, min_: int, max_: int) -> None:
+        self._length_label.setText(f"/ {max_}")
+
+
+class LabeledVisibilitySlider(QLabeledSlider):
+    def _visibility(self, settings: dict[str, Any]) -> None:
+        if settings["index"] != self.name:
+            return
+        if settings["show"]:
+            self.show()
+        else:
+            self.hide()
+        self.setRange(0, settings["max"])

--- a/control/src/isim_control/eda/_util/zarr_saver.py
+++ b/control/src/isim_control/eda/_util/zarr_saver.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import atexit
+import json
+import os.path
+import shutil
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Protocol
+
+from ._5d_writer_base import _5DWriterBase
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import ContextManager, Sequence, TypedDict
+
+    import numpy as np
+    import zarr
+    from fsspec import FSMap
+    from numcodecs.abc import Codec
+
+    class ZarrSynchronizer(Protocol):
+        def __getitem__(self, key: str) -> ContextManager: ...
+
+    class ArrayCreationKwargs(TypedDict, total=False):
+        compressor: str | Codec
+        fill_value: int | None
+        order: Literal["C", "F"]
+        synchronizer: ZarrSynchronizer | None
+        overwrite: bool
+        filters: Sequence[Codec] | None
+        cache_attrs: bool
+        read_only: bool
+        object_codec: Codec | None
+        dimension_separator: Literal["/", "."] | None
+        write_empty_chunks: bool
+
+
+POS_PREFIX = "p"
+
+
+class OMEZarrWriter(_5DWriterBase["zarr.Array"]):
+    """MDA handler that writes to a zarr file following the ome-ngff spec.
+
+    This implements v0.4
+    https://ngff.openmicroscopy.org/0.4/index.html
+
+    It also aims to be compatible with the xarray Zarr spec:
+    https://docs.xarray.dev/en/latest/internals/zarr-encoding-spec.html
+
+    Note: this does *not* currently calculate any additional pyramid levels.
+    But it would be easy to do so after acquisition.
+    Chunk size is currently 1 XY plane.
+
+    Zarr directory structure will be:
+
+    ```
+    root.zarr/
+    ├── .zgroup                 # group metadata
+    ├── .zattrs                 # contains ome-multiscales metadata
+    │
+    ├── p0                      # each position is a separate <=5D array
+    │   ├── .zarray
+    │   ├── .zattrs
+    │   └── t                   # nested directories for each dimension
+    │       └── c               # (only collected dimensions will be present)
+    │           └── z
+    │               └── y
+    │                   └── x   # chunks will be each XY plane
+    ├── ...
+    ├── pn
+    │   ├── .zarray
+    │   ├── .zattrs
+    │   └── t...
+    ```
+
+    Parameters
+    ----------
+    store: MutableMapping | str | None
+        Zarr store or path to directory in file system to write to.
+        Semantics are the same as for `zarr.group`: If a string, it is interpreted as a
+        path to a directory. If None, an in-memory store is used.  May also be any
+        mutable mapping or instance of `zarr.storage.BaseStore`.
+    overwrite : bool
+        If True, delete any pre-existing data in `store` at `path` before
+        creating the group. If False, raise an error if there is already data
+        in `store` at `path`. by default False.
+    synchronizer : ZarrSynchronizer | None, optional
+        Array synchronizer passed to `zarr.group`.
+    zarr_version : {2, 3, None}, optional
+        Zarr version passed to `zarr.group`.
+    array_kwargs : dict, optional
+        Keyword arguments passed to `zarr.group.create` when creating the arrays.
+        This may be used to set the zarr `compressor`, `fill_value`, `synchronizer`,
+        etc... Default is `{'dimension_separator': '/'}`.
+    minify_attrs_metadata : bool, optional
+        If True, zattrs metadata will be read from disk, minified, and written
+        back to disk at the end of a successful acquisition (to save space). Default is
+        False.
+    """
+
+    def __init__(
+        self,
+        store: MutableMapping | str | os.PathLike | FSMap | None = None,
+        *,
+        overwrite: bool = False,
+        synchronizer: ZarrSynchronizer | None = None,
+        zarr_version: Literal[2, 3, None] = None,
+        array_kwargs: ArrayCreationKwargs | None = None,
+        minify_attrs_metadata: bool = False,
+    ) -> None:
+        try:
+            import zarr
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "zarr is required to use this handler. Install with `pip install zarr`"
+            ) from e
+
+        super().__init__()
+
+        # main zarr group
+        self._group = zarr.group(
+            store,
+            overwrite=overwrite,
+            synchronizer=synchronizer,
+            zarr_version=zarr_version,
+        )
+
+        # if we don't check this here, we'll get an error when creating the first array
+        if (
+            not overwrite and any(self._group.arrays()) or self._group.attrs
+        ):  # pragma: no cover
+            path = self._group.store.path if hasattr(self._group.store, "path") else ""
+            raise ValueError(
+                f"There is already data in {path!r}. Use 'overwrite=True' to overwrite."
+            )
+
+        # passed to zarr.group.create
+        self._array_kwargs: ArrayCreationKwargs = array_kwargs or {}
+        self._array_kwargs.setdefault("dimension_separator", "/")
+        self._minify_metadata = minify_attrs_metadata
+
+    @classmethod
+    def in_tmpdir(
+        cls,
+        suffix: str | None = ".zarr",
+        prefix: str | None = "pymmcore_zarr_",
+        dir: str | PathLike[str] | None = None,
+        cleanup_atexit: bool = True,
+        **kwargs: Any,
+    ) -> OMEZarrWriter:
+        """Create OMEZarrHandler that writes to a temporary directory.
+
+        Parameters
+        ----------
+        suffix : str, optional
+            If suffix is specified, the file name will end with that suffix, otherwise
+            there will be no suffix.
+        prefix : str, optional
+            If prefix is specified, the file name will begin with that prefix, otherwise
+            a default prefix is used.
+        dir : str or PathLike, optional
+            If dir is specified, the file will be created in that directory, otherwise
+            a default directory is used (tempfile.gettempdir())
+        cleanup_atexit : bool, optional
+            Whether to automatically cleanup the temporary directory when the python
+            process exits. Default is True.
+        **kwargs
+            Remaining kwargs are passed to `OMEZarrHandler.__init__`
+        """
+        # same as zarr.storage.TempStore, but with option not to cleanup
+        path = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
+        if cleanup_atexit:
+
+            @atexit.register
+            def _atexit_rmtree(_path: str = path) -> None:
+                if os.path.isdir(_path):
+                    shutil.rmtree(_path)
+
+        return cls(path, **kwargs)
+
+    @property
+    def group(self) -> zarr.Group:
+        """Read-only access to the zarr group."""
+        return self._group
+
+    def finalize_metadata(self) -> None:
+        """Called by superclass in sequenceFinished.  Flush metadata to disk."""
+        # flush frame metadata to disk
+        while self.frame_metadatas:
+            key, metas = self.frame_metadatas.popitem()
+            if key in self.position_arrays:
+                self.position_arrays[key].attrs["frame_meta"] = metas
+
+        if self._minify_metadata:
+            self._minify_zattrs_metadata()
+
+    def new_array(self, key: str, dtype: np.dtype, sizes: dict[str, int]) -> zarr.Array:
+        """Create a new array in the group, under `key`."""
+        dims, shape = zip(*sizes.items())
+        ary: zarr.Array = self._group.create(
+            key,
+            shape=shape,
+            chunks=(1,) * len(shape[:-2]) + shape[-2:],  # single XY plane chunks
+            dtype=dtype,
+            **self._array_kwargs,
+        )
+
+        # add minimal OME-NGFF metadata
+        scales = self._group.attrs.get("multiscales", [])
+        scales.append(self._multiscales_item(ary.path, ary.path, dims))
+        self._group.attrs["multiscales"] = scales
+        ary.attrs["_ARRAY_DIMENSIONS"] = dims
+        if seq := self.current_sequence:
+            ary.attrs["useq_MDASequence"] = json.loads(seq.json(exclude_unset=True))
+        return ary
+
+    # # the superclass implementation is all we need
+    # def write_frame(
+    #     self, ary: zarr.Array, frame: np.ndarray, event: useq.MDAEvent
+    # ) -> None:
+    #     super().write_frame(ary, frame, event)
+
+    def _multiscales_item(self, path: str, name: str, axes: Sequence[str]) -> dict:
+        """ome-zarr multiscales image metadata.
+
+        https://ngff.openmicroscopy.org/0.4/index.html#multiscale-md
+        """
+        tforms = [{"scale": [1] * len(axes), "type": "scale"}]
+        return {
+            "axes": [{"name": ax, "type": AXTYPE.get(ax, "")} for ax in axes],
+            "datasets": [{"coordinateTransformations": tforms, "path": path}],
+            "name": name,
+            "version": "0.4",
+        }
+
+    def _minify_zattrs_metadata(self) -> None:
+        """Read, minify, and write zattrs metadata to disk.
+
+        Totally optional and just saves a little space since zattrs for arrays can
+        get big with all the metadata.
+
+        called during sequenceFinished if `minify_attrs_metadata=True`
+        """
+        from zarr.util import json_loads
+
+        store = self._group.store
+        for key in store.keys():
+            if key.endswith(".zattrs"):
+                data = json_loads(store[key])
+                # dump minified data back to disk
+                store[key] = json.dumps(data, separators=(",", ":")).encode("ascii")
+
+
+# https://ngff.openmicroscopy.org/0.4/index.html#axes-md
+AXTYPE = {
+    "x": "space",
+    "y": "space",
+    "z": "space",
+    "c": "channel",
+    "t": "time",
+    "p": "position",
+}

--- a/control/src/isim_control/eda/basic.py
+++ b/control/src/isim_control/eda/basic.py
@@ -1,9 +1,10 @@
 from isim_control.core import ISIMCore
 from useq import MDASequence
-from pymmcore_eda.actuator import MDAActuator
+from pymmcore_eda.actuator import MDAActuator, ButtonActuator
 from pymmcore_eda.queue_manager import QueueManager
 
 from qtpy.QtWidgets import QApplication
+from qtpy.QtCore import Signal, Qt
 
 from isim_control.settings_translate import load_settings
 
@@ -11,6 +12,16 @@ if __name__ == "__main__":
     app = QApplication([])
     mmc = ISIMCore()
     settings = load_settings()
+    settings['twitchers'] = False
+    settings['exposure_time'] = 0.05
+    settings.calculate_ni_settings(settings['exposure_time']*1000)
+
+    events_class = mmc.events.__class__
+    new_cls = type(
+        events_class.__name__, events_class.__bases__,
+        {**events_class.__dict__, 'liveFrameReady': Signal(object, object, dict)},
+    )
+    mmc.events.__class__ = new_cls
 
     # Load and init the iSIM
     mmc.loadSystemConfiguration("C:/iSIM/iSIM/mm-configs/pymmcore_plus.cfg")
@@ -23,21 +34,26 @@ if __name__ == "__main__":
     mmc.setProperty("Quantum_561nm", "Laser Operation", "On")
     mmc.setProperty("MCL NanoDrive Z Stage", "Settling time (ms)", 30)
     mmc.setXYStageDevice("MicroDrive XY Stage")
-    mmc.setExposure(100)
+    mmc.setExposure(settings['exposure_time']*1000)
     mmc.setAutoShutter(False)
 
     # Set the engine that is specific for the iSIM
     from isim_control.ni import live, acquisition, devices
     isim_devices = devices.NIDeviceGroup(settings=settings)
     acq_engine = acquisition.AcquisitionEngine(mmc, isim_devices, settings)
+    acq_engine.start_xy_position = mmc.getXYPosition()
+    acq_engine.use_filter_wheel = False
+    acq_engine.previous_exposure = settings['exposure_time']*1000
+    acq_engine.eda = True
+    acq_engine.use_hardware_sequencing = False
+    acq_engine.update_settings(settings)
+    acq_engine.adjust_camera_exposure(settings['camera']['exposure']*1000)
+    isim_devices.update_settings(settings)
+
+
     mmc.mda.set_engine(acq_engine)
 
-
-    from isim_control.gui.preview import iSIMPreview
-    preview = iSIMPreview(mmcore=mmc)
-
-
-
+    # EDA components
     queue_manager = QueueManager(mmcore=mmc)
 
     mda_sequence = MDASequence(
@@ -47,6 +63,14 @@ if __name__ == "__main__":
     base_actuator = MDAActuator(queue_manager, mda_sequence)
     base_actuator.wait = False
 
+    b_actuator = ButtonActuator(queue_manager)
+    b_actuator.channel_name = "561"
+
+
     mmc.run_mda(queue_manager.acq_queue_iterator)
 
+    base_actuator.thread.start()
+    b_actuator.thread.start()
     app.exec_()
+    base_actuator.thread.join()
+    b_actuator.thread.join()

--- a/control/src/isim_control/eda/eda.py
+++ b/control/src/isim_control/eda/eda.py
@@ -1,0 +1,52 @@
+from isim_control.core import ISIMCore
+from useq import MDASequence
+from pymmcore_eda.actuator import MDAActuator
+from pymmcore_eda.queue_manager import QueueManager
+
+from qtpy.QtWidgets import QApplication
+
+from isim_control.settings_translate import load_settings
+
+if __name__ == "__main__":
+    app = QApplication([])
+    mmc = ISIMCore()
+    settings = load_settings()
+
+    # Load and init the iSIM
+    mmc.loadSystemConfiguration("C:/iSIM/iSIM/mm-configs/pymmcore_plus.cfg")
+    print("System loaded")
+    mmc.setCameraDevice("PrimeB_Camera")
+    mmc.setProperty("PrimeB_Camera", "TriggerMode", "Edge Trigger")
+    mmc.setProperty("PrimeB_Camera", "ReadoutRate", "100MHz 16bit")
+
+    mmc.setProperty("Sapphire", "State", 1)
+    mmc.setProperty("Quantum_561nm", "Laser Operation", "On")
+    mmc.setProperty("MCL NanoDrive Z Stage", "Settling time (ms)", 30)
+    mmc.setXYStageDevice("MicroDrive XY Stage")
+    mmc.setExposure(100)
+    mmc.setAutoShutter(False)
+
+    # Set the engine that is specific for the iSIM
+    from isim_control.ni import live, acquisition, devices
+    isim_devices = devices.NIDeviceGroup(settings=settings)
+    acq_engine = acquisition.AcquisitionEngine(mmc, isim_devices, settings)
+    mmc.mda.set_engine(acq_engine)
+
+
+    from isim_control.gui.preview import iSIMPreview
+    preview = iSIMPreview(mmcore=mmc)
+
+
+
+    queue_manager = QueueManager(mmcore=mmc)
+
+    mda_sequence = MDASequence(
+        channels=["488"],
+        time_plan={"interval": 0.5, "loops": 10},
+    )
+    base_actuator = MDAActuator(queue_manager, mda_sequence)
+    base_actuator.wait = False
+
+    mmc.run_mda(queue_manager.acq_queue_iterator)
+
+    app.exec_()

--- a/control/src/isim_control/eda/gui.py
+++ b/control/src/isim_control/eda/gui.py
@@ -1,19 +1,24 @@
+import os
+import copy
+
+from pymmcore_widgets import StageWidget, GroupPresetTableWidget
+from qtpy.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Signal, Qt
+
 from isim_control.core import ISIMCore
+
+
 from useq import MDASequence
 from pymmcore_eda.actuator import MDAActuator, ButtonActuator
 from pymmcore_eda.queue_manager import QueueManager
-
-from qtpy.QtWidgets import QApplication
-from qtpy.QtCore import Signal, Qt
-
 from isim_control.settings_translate import load_settings
 
-import threading
+os.environ["PYMM_STRICT_INIT_CHECKS"] = 'true'
+os.environ["PYMM_PARALLEL_INIT"] = 'true'
 
-
-if __name__ == "__main__":
+def main():
     app = QApplication([])
-    mmc = ISIMCore()
+    mmc = ISIMCore.instance()
     settings = load_settings()
     settings['twitchers'] = False
     settings['exposure_time'] = 0.05
@@ -54,36 +59,61 @@ if __name__ == "__main__":
     isim_devices.update_settings(settings)
     mmc.mda.set_engine(acq_engine)
 
-    # GUI things
-    from isim_control.pubsub import Publisher, Broker
-    broker = Broker()
-    pub = Publisher(broker.pub_queue)
 
-    from isim_control.gui.output import OutputGUI
-    output = OutputGUI(mmc, settings, broker, Publisher(broker.pub_queue))
-    output.show()
+    # Adaptive in process writer
+    from pymmcore_eda.writer import AdaptiveWriter
+    from pathlib import Path
+    loc = Path("C:/Users/stepp/Desktop/MyOME.ome.zarr")
+    writer = AdaptiveWriter(path=loc, delete_existing=True)
+    mmc.mda.events.sequenceStarted.connect(writer.sequenceStarted)
+    mmc.mda.events.sequenceFinished.connect(writer.sequenceFinished)
+    mmc.mda.events.frameReady.connect(writer.frameReady)
+    from pymmcore_eda.event_hub import EventHub
+    EventHub(mmc.mda, writer)
 
-    print(settings['path'])
+
+    CHANNELS = ("488", "LED")
+    # Viewer
+    from pymmcore_eda._eda_sequence import EDASequence
+    from isim_control.eda._stack_viewer._datastore import QOMEZarrDatastore
+    from isim_control.eda._stack_viewer import StackViewer
+    eda_sequence = EDASequence(channels=CHANNELS)
+    datastore = QOMEZarrDatastore(None, overwrite=True)
+    datastore._mm_config = mmc.getSystemState().dict()
+    mmc.mda.events.frameReady.connect(datastore.frameReady)
+    viewer = StackViewer(datastore=datastore, mmcore=mmc,
+                            sequence=eda_sequence, transform=(90, False, True))
+    # This has to use all the axis to init the datastore correctly
+    # And the maximal number of frames that can happen
+    mda_sequence = MDASequence(channels=CHANNELS,
+                               time_plan={'interval': 1, 'loops': 100})
+    datastore.sequenceStarted(mda_sequence)
+    viewer.show()
+
     # EDA components
-    queue_manager = QueueManager(mmcore=mmc)
+    queue_manager = QueueManager(eda_sequence=eda_sequence, mmcore=mmc)
 
     mda_sequence = MDASequence(
-        channels=["488"],
-        time_plan={"interval": 0.5, "loops": 60},
+        channels=[CHANNELS[0]],
+        time_plan={"interval": 0.5, "loops": 10},
     )
     base_actuator = MDAActuator(queue_manager, mda_sequence)
     base_actuator.wait = False
 
     b_actuator = ButtonActuator(queue_manager)
-    b_actuator.channel_name = "LED"
+    b_actuator.channel_name = CHANNELS[1]
 
-    pub.publish("gui", "acquisition_start", [True])
+    # pub = Publisher(broker.pub_queue)
+    # pub.publish("gui", "acquisition_start", [True])
     mmc.run_mda(queue_manager.acq_queue_iterator)
 
     base_actuator.thread.start()
     b_actuator.thread.start()
     app.exec_()
+    base_actuator.thread.join()
+    b_actuator.thread.join()
+    # broker.stop()
+    # viewer.shutdown()
 
-    print("Shut down")
-    output.shutdown()
-    broker.stop()
+if __name__ == "__main__":
+    main()

--- a/control/src/isim_control/eda/gui.py
+++ b/control/src/isim_control/eda/gui.py
@@ -95,7 +95,7 @@ def main():
 
     mda_sequence = MDASequence(
         channels=[CHANNELS[0]],
-        time_plan={"interval": 0.5, "loops": 10},
+        time_plan={"interval": 1, "loops": 30},
     )
     base_actuator = MDAActuator(queue_manager, mda_sequence)
     base_actuator.wait = False

--- a/control/src/isim_control/io/ome_tiff_writer.py
+++ b/control/src/isim_control/io/ome_tiff_writer.py
@@ -44,6 +44,7 @@ class OMETiffWriter:
         self._view_settings = load_settings("live_view")
         # create an empty OME-TIFF file
         self._folder = Path(folder)
+        print(self._folder)
         self._settings = settings
         self._mm_config = mm_config
         self.advanced_ome = advanced_ome

--- a/control/src/isim_control/ni/testing/mda_listeners.py
+++ b/control/src/isim_control/ni/testing/mda_listeners.py
@@ -19,7 +19,6 @@ class MyProcessor(QtWidgets.QWidget):
     # grab info about the full experiment at the beginning
 
     def frameReady(self, frame, event):
-        print("FRAME READY")
         # if not using the sequenceStarted method
         if event.sequence:
             # grab info from event.sequence

--- a/control/src/isim_control/run.py
+++ b/control/src/isim_control/run.py
@@ -66,12 +66,12 @@ def main():
         broker = Broker()
         from isim_control.ni import live, acquisition, devices
         isim_devices = devices.NIDeviceGroup(settings=settings)
-        from isim_control.io.monogram import MonogramCC
         acq_engine = acquisition.AcquisitionEngine(mmc, isim_devices, settings)
         live_engine = live.LiveEngine(task=acq_engine.task, mmcore=mmc, settings=settings,
                                         device_group=isim_devices)
         mmc.mda.set_engine(acq_engine)
 
+        from isim_control.io.monogram import MonogramCC
         monogram = MonogramCC(mmcore=mmc, publisher=Publisher(broker.pub_queue))
         broker.attach(monogram)
         stage = iSIM_StageWidget(mmc)

--- a/control/src/isim_control/settings_translate.py
+++ b/control/src/isim_control/settings_translate.py
@@ -5,7 +5,7 @@ from isim_control.settings import iSIMSettings
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
-    from useq import MDASequence
+from useq import MDASequence
 import json
 from pathlib import Path
 from datetime import timedelta

--- a/control/src/isim_control/settings_translate.py
+++ b/control/src/isim_control/settings_translate.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 from isim_control.settings import iSIMSettings
-from pymmcore_plus import CMMCorePlus
-from useq import MDASequence
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pymmcore_plus import CMMCorePlus
+    from useq import MDASequence
 import json
 from pathlib import Path
 from datetime import timedelta

--- a/control/uv.lock
+++ b/control/uv.lock
@@ -264,7 +264,7 @@ requires-dist = [
     { name = "nidaqmx" },
     { name = "ome-types" },
     { name = "pygame" },
-    { name = "pymmcore-eda", editable = "../../pymmcore-eda" },
+    { name = "pymmcore-eda", git = "https://github.com/LEB-EPFL/pymmcore-eda.git?rev=v0.1.1" },
     { name = "pymmcore-plus", extras = ["io"] },
     { name = "pymmcore-widgets", extras = ["pyqt6"] },
     { name = "pyqt6", marker = "extra == 'full'" },
@@ -709,24 +709,12 @@ wheels = [
 
 [[package]]
 name = "pymmcore-eda"
-source = { editable = "../../pymmcore-eda" }
+version = "0.1.1"
+source = { git = "https://github.com/LEB-EPFL/pymmcore-eda.git?rev=v0.1.1#ec7be48ab4d076620eec191c7c33fbd12683e4cc" }
 dependencies = [
     { name = "pymmcore-plus" },
     { name = "sortedcontainers" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "ipython", marker = "extra == 'dev'" },
-    { name = "mypy", marker = "extra == 'dev'" },
-    { name = "pdbpp", marker = "sys_platform != 'win32' and extra == 'dev'" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pymmcore-plus" },
-    { name = "ruff", marker = "extra == 'dev'" },
-    { name = "sortedcontainers", specifier = ">=2.4.0" },
-    { name = "tensorstore-stubs", marker = "extra == 'dev'" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "pymmcore-plus"


### PR DESCRIPTION
This adds some basic examples of how to run an EDA acquisition on the iSIM using the pymmcore-eda backend. Additionally it transfers over the viewer infrastructure for adaptive acquisitions we use on the Zeiss to follow the acquisition.